### PR TITLE
added change trigger to lat and lng fields on dragend

### DIFF
--- a/InputfieldLeafletMapMarker.js
+++ b/InputfieldLeafletMapMarker.js
@@ -26,7 +26,7 @@ var InputfieldLeafletMapMarker = {
         var coder = L.Control.Geocoder.nominatim(),
         geocoder = L.Control.geocoder({
             geocoder: geocoder, placeholder: ''
-        }).addTo(map)
+        }).addTo(map);
 
         var marker = L.marker(
             [lat,lng],
@@ -95,8 +95,8 @@ var InputfieldLeafletMapMarker = {
 
         marker.on('dragend', function(event) {
             var result = marker.getLatLng();
-            $lat.val(result.lat);
-            $lng.val(result.lng);
+            $lat.val(result.lat).trigger('change');
+            $lng.val(result.lng).trigger('change');
 
             //reverse geocoding displays in the adress field
             coder.reverse(marker.getLatLng(), map.options.crs.scale(map.getZoom()), function(results) {


### PR DESCRIPTION
Hi Mats,
I'm working on a module that can optionally interact with this one. On dragend of the marker, new lat and lng values are populated. But jQuery doesn't fire change events on $lat.val(result.lat). So I need to trigger them manually to let my module know that values have changed.
The changes in this pull request won't interfere with other functionality in this module or cause performance issues. So it would be great if you could merge. Otherwise I'd have to find other ways to make my module work.