### PR TITLE
added custom event name to change trigger

### DIFF
--- a/InputfieldLeafletMapMarker.js
+++ b/InputfieldLeafletMapMarker.js
@@ -72,7 +72,6 @@ var InputfieldLeafletMapMarker = {
 
 
         $lng.change(function(event) {
-
             marker.setLatLng([$lat.val(),$lng.val()]);
             map.setView(marker.getLatLng(), 9);
             coder.reverse(marker.getLatLng(), map.options.crs.scale(map.getZoom()), function(results) {
@@ -95,8 +94,8 @@ var InputfieldLeafletMapMarker = {
 
         marker.on('dragend', function(event) {
             var result = marker.getLatLng();
-            $lat.val(result.lat).trigger('change');
-            $lng.val(result.lng).trigger('change');
+            $lat.val(result.lat).trigger('change.custom');
+            $lng.val(result.lng).trigger('change.custom');
 
             //reverse geocoding displays in the adress field
             coder.reverse(marker.getLatLng(), map.options.crs.scale(map.getZoom()), function(results) {


### PR DESCRIPTION
Sorry to be bothering you.
I found that the dragging of the marker triggers a reset of the zoom level (same as when you enter lat and lng manually).
I gave the trigger a 'custom' event name to avoid that. Please merge again. Thank you.