### PR TITLE
Set a higher priority for the hook

### DIFF
--- a/MarkupAddInlineScript.module
+++ b/MarkupAddInlineScript.module
@@ -28,7 +28,7 @@ class MarkupAddInlineScript extends WireData implements Module {
      *
      */
     public function init() {
-        $this->addHookAfter('Page::render', $this, 'addInlineScript');
+        $this->addHookAfter('Page::render', $this, 'addInlineScript', array('priority'=>'200'));
     }
 
     public function addInlineScript($event) {


### PR DESCRIPTION
I was having problems with the leaflet map not being initialized because the javascript was not being included on the page because the hook priority of this module was 100.1 and the priority of the TemplateEngineFactory::hookRender() was 100.3.

I think 100 is the default priority.  I think we can safely raise the priority of this module to 200 so that it runs after TemplateEngineFactory and others.

For more details on the problem I having see https://processwire.com/talk/topic/9745-module-leaflet-map/?do=findComment&comment=140014

I'm also guessing this would also need to be applied to both branches of this module?

Hope that helps!