### PR TITLE
Added scrollWheelZoom option to MarkupLeafletMap

### DIFF
--- a/MarkupLeafletMap.js
+++ b/MarkupLeafletMap.js
@@ -43,7 +43,7 @@ function jsMarkupLeafletMap() {
 
     this._currentURL = '';
     this.init = function(mapID, lat, lng, provider) {
-        if(lat != 0) this.map = L.map(mapID, {center: [lat, lng], zoom: this.options.zoom} );
+        if(lat != 0) this.map = L.map(mapID, {center: [lat, lng], zoom: this.options.zoom, scrollWheelZoom: this.options.scrollWheelZoom,} );
         L.tileLayer.provider(provider).addTo(this.map);
     }
 

--- a/MarkupLeafletMap.module
+++ b/MarkupLeafletMap.module
@@ -53,6 +53,9 @@
  * // set to true to automatically adjust maximum zoom level to default zoom
  * 'maxZoom' => true
  *
+ * // set to false to disable the scroll wheel zoom
+ * 'scrollWheelZoom' => true
+ *
  * // map ID attribute
  * 'id' => "mgmap"
  *
@@ -137,6 +140,7 @@ class MarkupLeafletMap extends WireData implements Module {
             'lng' => $field->defaultLng,
             'provider' => $field->defaultProvider,
             'maxZoom' => false,
+            'scrollWheelZoom' => true,
             'icon' => '', // url to icon (blank=use default)
             'iconHover' => '', // url to icon when hovered (default=none)
             'shadow' => '', // url to icon shadow (blank=use default)
@@ -229,6 +233,7 @@ LINES;
         $inlineScript = "<script type='text/javascript'>\n$(function() {\n" .
             "var $id = new jsMarkupLeafletMap();\n" .
             "$id.setOption('zoom', $zoom);\n" .
+            "$id.setOption('scrollWheelZoom', {$options['scrollWheelZoom']});\n" .
             $options['init'] . "\n" .
             "$id.init('$id', $lat, $lng, '$provider');\n" .
             "var default_marker_icon = L.AwesomeMarkers.icon({ icon: '{$options['markerIcon']}', iconColor: '{$options['markerIconColour']}', prefix: 'fa', markerColor: '{$options['markerColour']}' });\n";

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Option | Notes
 `markerColour` | The default colour of the marker body that surrounds the icon. (type: string; default 'darkblue'.) See Leaflet.AwesomeMarker's [markerColor](https://github.com/lvoogdt/Leaflet.awesome-markers#properties) entry for the available colours - they are limited.
 `markerFormatter` | A PHP callback function (taking a PW `$page` and AwesomeMarker `$marker_options` as arguments) for customising the look of any marker on the map. This is called once for each marker being placed on the map and allows the defaults to be overridden for each marker.
 `provider` | Defines which tile layer provider to use. (type: string; default: OpenStreetMap.Mapnik)
+`scrollWheelZoom` | Whether to allow zooming with the mouse wheel. (type: boolean; default: true)
 
 ----------
 


### PR DESCRIPTION
I had to add this option to disable the scroll zoom because large leaflet maps on a page make it hard to scroll the page.

It works for me.  Scrolling with the middle mouse wheel doesn't automatically zoom the map anymore when the web page is scrolled vertically.

Hope that helps