### PR TITLE
Added scrollWheelZoom checkbox

### DIFF
--- a/Control.Geocoder.js
+++ b/Control.Geocoder.js
@@ -340,7 +340,7 @@
         },
 
         geocode: function(query, cb, context) {
-            L.Control.Geocoder.jsonp(this.options.serviceUrl + 'search/', L.extend({
+            L.Control.Geocoder.jsonp(this.options.serviceUrl + 'search', L.extend({
                 q: query,
                 limit: 5,
                 format: 'json',
@@ -367,7 +367,7 @@
         },
 
         reverse: function(location, scale, cb, context) {
-            L.Control.Geocoder.jsonp(this.options.serviceUrl + 'reverse/', L.extend({
+            L.Control.Geocoder.jsonp(this.options.serviceUrl + 'reverse', L.extend({
                 lat: location.lat,
                 lon: location.lng,
                 zoom: Math.round(Math.log(scale / 256) / Math.log(2)),

--- a/Control.Geocoder.js
+++ b/Control.Geocoder.js
@@ -340,7 +340,7 @@
         },
 
         geocode: function(query, cb, context) {
-            L.Control.Geocoder.jsonp(this.options.serviceUrl + 'search', L.extend({
+            L.Control.Geocoder.jsonp(this.options.serviceUrl + 'search/', L.extend({
                 q: query,
                 limit: 5,
                 format: 'json',
@@ -367,7 +367,7 @@
         },
 
         reverse: function(location, scale, cb, context) {
-            L.Control.Geocoder.jsonp(this.options.serviceUrl + 'reverse', L.extend({
+            L.Control.Geocoder.jsonp(this.options.serviceUrl + 'reverse/', L.extend({
                 lat: location.lat,
                 lon: location.lng,
                 zoom: Math.round(Math.log(scale / 256) / Math.log(2)),

--- a/InputfieldLeafletMapMarker.js
+++ b/InputfieldLeafletMapMarker.js
@@ -133,6 +133,11 @@ var InputfieldLeafletMapMarker = {
                 map.invalidateSize();
             }, 200);
         });
+
+        if ($('div.InputfieldLeafletMapMarkerMap').hasClass('scrollwheel-disabled')){
+            map.scrollWheelZoom.disable()
+        }
+
     }
 };
 

--- a/InputfieldLeafletMapMarker.module
+++ b/InputfieldLeafletMapMarker.module
@@ -41,6 +41,7 @@ class InputfieldLeafletMapMarker extends Inputfield {
         require_once(dirname(__FILE__) . '/LeafletMapMarker.php');
         $this->set('defaultAddr', self::defaultAddr);
         $this->set('defaultZoom', 12);
+        $this->set('scrollWheelZoom', false);
         $this->set('defaultLat', '');
         $this->set('defaultLng', '');
         $this->set('height', 500);
@@ -108,6 +109,7 @@ class InputfieldLeafletMapMarker extends Inputfield {
         $mapType = $this->defaultType;
         $provider = $this->defaultProvider;
         $height = $this->height ? (int) $this->height : 300;
+        $scrollWheelZoom = $this->scrollWheelZoom;
 
         $labels = array(
             'addr' => $this->_('Address'),
@@ -154,7 +156,9 @@ class InputfieldLeafletMapMarker extends Inputfield {
 
 _OUT;
 
-        $out .= "<div class='InputfieldLeafletMapMarkerMap' " .
+        ($this->scrollWheelZoom == true) ? $class = ' scrollwheel-disabled' : $class = '';
+
+        $out .= "<div class='InputfieldLeafletMapMarkerMap{$class}' " .
             "id='_{$id}_map' " .
             "style='height: {$height}px' " .
             "data-lat='$marker->lat' " .
@@ -291,6 +295,15 @@ _OUT;
         $field->description = $this->_('Enter a value between 1 and 18.');  // Zoom level description
         $field->attr('value', $this->defaultZoom);
         $field->attr('type', 'number');
+        $inputfields->add($field);
+
+        $field = $this->modules->get('InputfieldCheckbox');
+        $field->attr('name', 'scrollWheelZoom');
+        $field->label = $this->_('Scrollwheel Zoom Disable');
+        $field->label2 = $this->_('Check this to lock Scrollwheel Zoom ad prevent unwanted zoom in admin page edit');
+        $field->description = $this->_('Lock zoom by mouse wheel scroll');  // Zoom level description
+        $field->attr('value', $this->scrollWheelZoom ? $this->scrollWheelZoom : 0 );
+        $field->attr('checked', $this->scrollWheelZoom === 1 ? 'checked' : '' );
         $inputfields->add($field);
 
         $field = $this->modules->get('InputfieldSelect');


### PR DESCRIPTION
**This PR is applicable for ADMIN side on page editing, avoiding map zooming in/out when scrolling along the page.**

Checkbox to disable map zoom on mouse wheel scroll:

**InputfieldLeafletMapMarker.module** has new field in configuration func, one line (:44) added in __construct(), one line (:112) added in ___render() and one class addition in markup to set a specific html class (triggered by JS), on line 159 and 161

**InputfieldLeafletMapMarker.js** has a check for the html class to set option as map.scrollWheelZoom.disable(), on lines 137-139
[InputfieldLeafletMarker_files.zip](https://github.com/FriendsOfProcessWire/FieldtypeLeafletMapMarker/files/12061499/InputfieldLeafletMarker_files.zip)
