### PR TITLE
remove no longer supported slash after /search or /reverse call of nominatim.openstreetmap.org

### DIFF
--- a/Control.Geocoder.js
+++ b/Control.Geocoder.js
@@ -340,7 +340,7 @@
         },
 
         geocode: function(query, cb, context) {
-            L.Control.Geocoder.jsonp(this.options.serviceUrl + 'search/', L.extend({
+            L.Control.Geocoder.jsonp(this.options.serviceUrl + 'search', L.extend({
                 q: query,
                 limit: 5,
                 format: 'json',
@@ -367,7 +367,7 @@
         },
 
         reverse: function(location, scale, cb, context) {
-            L.Control.Geocoder.jsonp(this.options.serviceUrl + 'reverse/', L.extend({
+            L.Control.Geocoder.jsonp(this.options.serviceUrl + 'reverse', L.extend({
                 lat: location.lat,
                 lon: location.lng,
                 zoom: Math.round(Math.log(scale / 256) / Math.log(2)),


### PR DESCRIPTION
The address resolution of nominatim.openstreetmap.org did not work any longer, you need to remove the trailing slash before the question mark

Wrong Call
https://nominatim.openstreetmap.org/search/?q=berlin&limit=5&format=json&addressdetails=1&json_callback=_l_geocoder_0

Correct Call
https://nominatim.openstreetmap.org/search?q=berlin&limit=5&format=json&addressdetails=1&json_callback=_l_geocoder_0

Why it was changed:
https://github.com/osm-search/Nominatim/issues/3134